### PR TITLE
feat(RELEASE-951): Integrate Checkton for Linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,3 +43,20 @@ jobs:
         run: python -m pip install gitlint
       - name: Run gitlint check
         run: gitlint --commits origin/${{ github.event.pull_request.base.ref }}..HEAD
+  checkton:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run Checkton
+        id: checkton
+        uses: chmeliik/checkton@v0.1.2
+        with:
+          fail-on-findings: false
+      - name: Upload SARIF File
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.checkton.outputs.sarif }}
+          category: checkton


### PR DESCRIPTION
This updats the linting workflow by adding Checkton.
Checkton will review code for linting errors.

Changes:
* Added a step to the workflow to run Checkton.
* Configured Checkton to upload the SARIF report.

Signed-off-by: Sean Conroy <sconroy@redhat.com>